### PR TITLE
make overflow visible for h2 span elements

### DIFF
--- a/assets/scss/_layout.sass
+++ b/assets/scss/_layout.sass
@@ -156,7 +156,7 @@ body
 
 			span
 				flex-grow: 1;
-				overflow: hidden;
+				overflow: visible;
 				white-space: nowrap;
 				text-overflow: ellipsis;
 


### PR DESCRIPTION
I noticed that in the `h2` `span` elements were being clipped when there were any hanging characters such as `g` or `y` (see picture). I found that changing the overflow values from `hidden` to `visible` for `h2.span` elements in this scss file allowed the low-hanging characters to be rendered without clipping. If there's a better way to do this, or if this conflicts in any way, feel free to hit it with the `reject` stamp.

<img width="617" alt="Screen Shot 2020-07-22 at 8 49 58 AM" src="https://user-images.githubusercontent.com/26355516/88201759-b6f61880-cbfc-11ea-842d-4621aeeab470.png">
